### PR TITLE
Accept CLI arguments for umm:module:install

### DIFF
--- a/src/module/install.js
+++ b/src/module/install.js
@@ -8,11 +8,37 @@ module.exports = () => {
     return;
   }
 
-  synchronize(
-    path.join(info.package_path, 'Assets'),
-    path.join(info.base_path, 'Assets', 'Modules', info.module_name),
-    {
-      remove_deleted_files: true
+  let target_directory_list = process.argv;
+  target_directory_list.shift();
+  target_directory_list.shift();
+  if (target_directory_list.length == 0) {
+    // 引数なしの場合、Assets ディレクトリ以下をモジュールディレクトリ直下にコピー
+    //   `npm run umm:module:install`
+    // の場合、モジュールの Assets/ 以下が丸っと
+    //   `Assets/Modules/umm@any_module/`
+    // にコピーされる
+    synchronize(
+      path.join(info.package_path, 'Assets'),
+      path.join(info.base_path, 'Assets', 'Modules', info.module_name),
+      {
+        remove_deleted_files: true
+      }
+    );
+  } else {
+    // 引数ありの場合、引数ディレクトリ以下をモジュールディレクトリ以下にコピー
+    //   `npm run umm:module:install Hoge Fuga`
+    // の場合、モジュールの Hoge/ と Fuga/ 以下がそれぞれ
+    //   `Assets/Modules/umm@any_module/Hoge/`
+    //   `Assets/Modules/umm@any_module/Fuga/`
+    // にコピーされる
+    for (let target_directory of target_directory_list) {
+      synchronize(
+        path.join(info.package_path, target_directory),
+        path.join(info.base_path, 'Assets', 'Modules', info.module_name, target_directory),
+        {
+          remove_deleted_files: true
+        }
+      );
     }
-  );
+  }
 };


### PR DESCRIPTION
## What

* Can specify the directory for installation by command line arguments.

### No arguments

`npm run umm:module:install`

* Copy assets from `Assets/` directory of module into `Assets/Modules/<module_name>/`.

### Any arguments

`npm run umm:module:install Foo Bar`

* Copy assets from `Foo/` and `Bar/` directory of module into `Assets/Modules/<module_name>/Foo/` and `Assets/Modules/<module_name>/Bar/`.
